### PR TITLE
feat: allow settings to be saved and imported later

### DIFF
--- a/src/i18n/message/app/option-resource.json
+++ b/src/i18n/message/app/option-resource.json
@@ -131,6 +131,8 @@
         "exportSuccess": "设置导出成功",
         "importSuccess": "设置导入成功",
         "importError": "导入失败：无效的设置文件",
+        "importConfirm": "设置导入成功，请刷新页面以应用更改！",
+        "reloadButton": "刷新",
         "defaultValue": "默认值: {default}"
     },
     "zh_TW": {
@@ -264,6 +266,8 @@
         "exportSuccess": "設定匯出成功",
         "importSuccess": "設定匯入成功",
         "importError": "匯入失敗：無效的設定檔案",
+        "importConfirm": "設定匯入成功，請重新整理頁面以套用變更！",
+        "reloadButton": "重新整理",
         "defaultValue": "預設值：{default}"
     },
     "en": {
@@ -398,6 +402,8 @@
     "exportSuccess": "Settings exported successfully",
     "importSuccess": "Settings imported successfully",
     "importError": "Import failed: Invalid settings file",
+    "importConfirm": "Settings imported successfully, please reload the page to apply changes!",
+    "reloadButton": "Reload",
     "defaultValue": "Default: {default}"
     },
     "ja": {
@@ -531,6 +537,8 @@
         "exportSuccess": "設定が正常にエクスポートされました",
         "importSuccess": "設定が正常にインポートされました",
         "importError": "インポートに失敗しました：無効な設定ファイル",
+        "importConfirm": "設定が正常にインポートされました。変更を適用するためにページをリロードしてください！",
+        "reloadButton": "リロード",
         "defaultValue": "デフォルト値：{default}"
     },
     "pt_PT": {

--- a/src/i18n/message/app/option-resource.json
+++ b/src/i18n/message/app/option-resource.json
@@ -126,6 +126,11 @@
         },
         "resetButton": "恢复默认",
         "resetSuccess": "成功重置为默认值",
+        "exportButton": "导出设置",
+        "importButton": "导入设置",
+        "exportSuccess": "设置导出成功",
+        "importSuccess": "设置导入成功",
+        "importError": "导入失败：无效的设置文件",
         "defaultValue": "默认值: {default}"
     },
     "zh_TW": {
@@ -254,6 +259,11 @@
         },
         "resetButton": "重設",
         "resetSuccess": "已恢復預設值！",
+        "exportButton": "匯出設定",
+        "importButton": "匯入設定",
+        "exportSuccess": "設定匯出成功",
+        "importSuccess": "設定匯入成功",
+        "importError": "匯入失敗：無效的設定檔案",
         "defaultValue": "預設值：{default}"
     },
     "en": {
@@ -381,9 +391,14 @@
             "title": "Accessibility",
             "chartDecal": "{input} Whether to display the chart decal"
         },
-        "resetButton": "Reset",
-        "resetSuccess": "Reset to default successfully!",
-        "defaultValue": "Default: {default}"
+    "resetButton": "Reset",
+    "resetSuccess": "Reset to default successfully!",
+    "exportButton": "Export Settings",
+    "importButton": "Import Settings",
+    "exportSuccess": "Settings exported successfully",
+    "importSuccess": "Settings imported successfully",
+    "importError": "Import failed: Invalid settings file",
+    "defaultValue": "Default: {default}"
     },
     "ja": {
         "yes": "はい",
@@ -511,6 +526,11 @@
         },
         "resetButton": "リセット",
         "resetSuccess": "デフォルトに正常にリセット",
+        "exportButton": "設定をエクスポート",
+        "importButton": "設定をインポート",
+        "exportSuccess": "設定が正常にエクスポートされました",
+        "importSuccess": "設定が正常にインポートされました",
+        "importError": "インポートに失敗しました：無効な設定ファイル",
         "defaultValue": "デフォルト値：{default}"
     },
     "pt_PT": {

--- a/src/i18n/message/app/option.ts
+++ b/src/i18n/message/app/option.ts
@@ -124,6 +124,11 @@ export type OptionMessage = {
     }
     resetButton: string
     resetSuccess: string
+    exportButton: string
+    importButton: string
+    exportSuccess: string
+    importSuccess: string
+    importError: string
     defaultValue: string
 }
 

--- a/src/i18n/message/app/option.ts
+++ b/src/i18n/message/app/option.ts
@@ -129,6 +129,8 @@ export type OptionMessage = {
     exportSuccess: string
     importSuccess: string
     importError: string
+    importConfirm: string
+    reloadButton: string
     defaultValue: string
 }
 

--- a/src/pages/app/components/Option/Tabs.tsx
+++ b/src/pages/app/components/Option/Tabs.tsx
@@ -1,6 +1,6 @@
 import { t } from "@app/locale"
 import { Download, Refresh, Upload } from "@element-plus/icons-vue"
-import { ElIcon, ElMessage, ElTabPane, ElTabs, TabPaneName } from "element-plus"
+import { ElIcon, ElMessage, ElMessageBox, ElTabPane, ElTabs, TabPaneName } from "element-plus"
 import { defineComponent, h, ref, useSlots } from "vue"
 import { useRouter } from "vue-router"
 import ContentContainer from "../common/ContentContainer"
@@ -37,9 +37,15 @@ const _default = defineComponent({
                 try {
                     const fileContent = await createFileInput()
                     await importSettings(fileContent)
-                    ElMessage.success(t(msg => msg.option.importSuccess))
-                    // Reload the page to reflect the imported settings
-                    window.location.reload()
+                    ElMessageBox({
+                        message: t(msg => msg.option.importConfirm),
+                        type: "success",
+                        confirmButtonText: t(msg => msg.option.reloadButton),
+                        closeOnPressEscape: false,
+                        closeOnClickModal: false
+                    }).then(() => {
+                        window.location.reload()
+                    }).catch(() => {/* do nothing */ })
                 } catch (error) {
                     const errorMessage = (error as Error).message
                     if (errorMessage === 'File selection cancelled' || errorMessage === 'No file selected') {
@@ -84,11 +90,10 @@ const _default = defineComponent({
                         name={exportButtonName}
                         v-slots={{
                             label: () => (
-                                <div>
+                                <div title={t(msg => msg.option.exportButton)}>
                                     <ElIcon>
                                         <Download />
                                     </ElIcon>
-                                    {t(msg => msg.option.exportButton)}
                                 </div>
                             )
                         }}
@@ -97,11 +102,10 @@ const _default = defineComponent({
                         name={importButtonName}
                         v-slots={{
                             label: () => (
-                                <div>
+                                <div title={t(msg => msg.option.importButton)}>
                                     <ElIcon>
                                         <Upload />
                                     </ElIcon>
-                                    {t(msg => msg.option.importButton)}
                                 </div>
                             )
                         }}

--- a/src/pages/app/components/Option/Tabs.tsx
+++ b/src/pages/app/components/Option/Tabs.tsx
@@ -1,12 +1,15 @@
 import { t } from "@app/locale"
-import { Refresh } from "@element-plus/icons-vue"
+import { Download, Refresh, Upload } from "@element-plus/icons-vue"
 import { ElIcon, ElMessage, ElTabPane, ElTabs, TabPaneName } from "element-plus"
 import { defineComponent, h, ref, useSlots } from "vue"
 import { useRouter } from "vue-router"
 import ContentContainer from "../common/ContentContainer"
 import { CATE_LABELS, changeQuery, type OptionCategory, parseQuery } from "./common"
+import { exportSettings, importSettings, createFileInput } from "./export-import"
 
 const resetButtonName = "reset"
+const exportButtonName = "export"
+const importButtonName = "import"
 
 const _default = defineComponent({
     emits: {
@@ -21,6 +24,30 @@ const _default = defineComponent({
                 const cate: OptionCategory = oldActiveName as OptionCategory
                 await new Promise<void>(res => ctx.emit('reset', cate, res))
                 ElMessage.success(t(msg => msg.option.resetSuccess))
+                return Promise.reject()
+            } else if (activeName === exportButtonName) {
+                try {
+                    await exportSettings()
+                    ElMessage.success(t(msg => msg.option.exportSuccess))
+                } catch (error) {
+                    ElMessage.error('Export failed: ' + (error as Error).message)
+                }
+                return Promise.reject()
+            } else if (activeName === importButtonName) {
+                try {
+                    const fileContent = await createFileInput()
+                    await importSettings(fileContent)
+                    ElMessage.success(t(msg => msg.option.importSuccess))
+                    // Reload the page to reflect the imported settings
+                    window.location.reload()
+                } catch (error) {
+                    const errorMessage = (error as Error).message
+                    if (errorMessage === 'File selection cancelled' || errorMessage === 'No file selected') {
+                        // User cancelled, don't show error message
+                    } else {
+                        ElMessage.error(t(msg => msg.option.importError))
+                    }
+                }
                 return Promise.reject()
             }
             // Change the query of current route
@@ -49,6 +76,32 @@ const _default = defineComponent({
                                         <Refresh />
                                     </ElIcon>
                                     {t(msg => msg.option.resetButton)}
+                                </div>
+                            )
+                        }}
+                    />
+                    <ElTabPane
+                        name={exportButtonName}
+                        v-slots={{
+                            label: () => (
+                                <div>
+                                    <ElIcon>
+                                        <Download />
+                                    </ElIcon>
+                                    {t(msg => msg.option.exportButton)}
+                                </div>
+                            )
+                        }}
+                    />
+                    <ElTabPane
+                        name={importButtonName}
+                        v-slots={{
+                            label: () => (
+                                <div>
+                                    <ElIcon>
+                                        <Upload />
+                                    </ElIcon>
+                                    {t(msg => msg.option.importButton)}
                                 </div>
                             )
                         }}

--- a/src/pages/app/components/Option/Tabs.tsx
+++ b/src/pages/app/components/Option/Tabs.tsx
@@ -36,6 +36,11 @@ const _default = defineComponent({
             } else if (activeName === importButtonName) {
                 try {
                     const fileContent = await createFileInput()
+                    if (fileContent === null) {
+                        // User cancelled file selection, don't show any message
+                        return Promise.reject()
+                    }
+
                     await importSettings(fileContent)
                     ElMessageBox({
                         message: t(msg => msg.option.importConfirm),
@@ -47,12 +52,7 @@ const _default = defineComponent({
                         window.location.reload()
                     }).catch(() => {/* do nothing */ })
                 } catch (error) {
-                    const errorMessage = (error as Error).message
-                    if (errorMessage === 'File selection cancelled' || errorMessage === 'No file selected') {
-                        // User cancelled, don't show error message
-                    } else {
-                        ElMessage.error(t(msg => msg.option.importError))
-                    }
+                    ElMessage.error(t(msg => msg.option.importError))
                 }
                 return Promise.reject()
             }

--- a/src/pages/app/components/Option/export-import.ts
+++ b/src/pages/app/components/Option/export-import.ts
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2025 Hengyang Zhang
- *
+ * Copyright (c) 2025 Aka Sai Lalith Kumar
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */
@@ -79,8 +78,9 @@ async function validateAndMergeSettings(importedSettings: Partial<timer.option.A
 
 /**
  * Create a file input element to select JSON file for import
+ * @returns Promise that resolves with file content string, or null if user cancels
  */
-export function createFileInput(): Promise<string> {
+export function createFileInput(): Promise<string | null> {
     return new Promise((resolve, reject) => {
         const input = document.createElement('input')
         input.type = 'file'
@@ -90,7 +90,8 @@ export function createFileInput(): Promise<string> {
         input.onchange = (event) => {
             const file = (event.target as HTMLInputElement).files?.[0]
             if (!file) {
-                reject(new Error('No file selected'))
+                // User didn't select a file (cancelled or closed dialog)
+                resolve(null)
                 return
             }
 
@@ -103,7 +104,7 @@ export function createFileInput(): Promise<string> {
             reader.readAsText(file)
         }
 
-        input.oncancel = () => reject(new Error('File selection cancelled'))
+        input.oncancel = () => resolve(null)
 
         document.body.appendChild(input)
         input.click()

--- a/src/pages/app/components/Option/export-import.tsx
+++ b/src/pages/app/components/Option/export-import.tsx
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2025 Hengyang Zhang
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+import optionHolder from "@service/components/option-holder"
+import { exportJson } from "@util/file"
+import { deserialize } from "@util/file"
+import { defaultOption } from "@util/constant/option"
+
+export interface ExportedSettings {
+    version: string
+    timestamp: number
+    settings: timer.option.AllOption
+}
+
+/**
+ * Export all settings to JSON file
+ */
+export async function exportSettings(): Promise<void> {
+    const settings = await optionHolder.get()
+    const exportData: ExportedSettings = {
+        version: '1.0',
+        timestamp: Date.now(),
+        settings
+    }
+
+    const fileName = `timer-settings-${new Date().toISOString().split('T')[0]}`
+    exportJson(exportData, fileName)
+}
+
+/**
+ * Import settings from JSON file
+ */
+export async function importSettings(jsonString: string): Promise<void> {
+    const importData = deserialize(jsonString) as ExportedSettings
+
+    if (!importData || !importData.settings) {
+        throw new Error('Invalid settings file format')
+    }
+
+    // Validate the imported settings structure
+    const validatedSettings = validateAndMergeSettings(importData.settings)
+
+    // Set the imported settings
+    await optionHolder.set(validatedSettings)
+}
+
+/**
+ * Validate imported settings and merge with defaults to ensure all required fields exist
+ */
+function validateAndMergeSettings(importedSettings: Partial<timer.option.AllOption>): timer.option.AllOption {
+    const defaults = defaultOption()
+
+    // Merge imported settings with defaults, giving preference to imported values
+    const mergedSettings: timer.option.AllOption = {
+        ...defaults,
+        ...importedSettings
+    }
+
+    // Ensure critical nested objects exist
+    if (importedSettings.backupAuths) {
+        mergedSettings.backupAuths = { ...defaults.backupAuths, ...importedSettings.backupAuths }
+    }
+
+    if (importedSettings.backupLogin) {
+        mergedSettings.backupLogin = { ...defaults.backupLogin, ...importedSettings.backupLogin }
+    }
+
+    if (importedSettings.backupExts) {
+        mergedSettings.backupExts = { ...defaults.backupExts, ...importedSettings.backupExts }
+    }
+
+    return mergedSettings
+}
+
+/**
+ * Create a file input element to select JSON file for import
+ */
+export function createFileInput(): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const input = document.createElement('input')
+        input.type = 'file'
+        input.accept = '.json'
+        input.style.display = 'none'
+
+        input.onchange = (event) => {
+            const file = (event.target as HTMLInputElement).files?.[0]
+            if (!file) {
+                reject(new Error('No file selected'))
+                return
+            }
+
+            const reader = new FileReader()
+            reader.onload = (e) => {
+                const content = e.target?.result as string
+                resolve(content)
+            }
+            reader.onerror = () => reject(new Error('Failed to read file'))
+            reader.readAsText(file)
+        }
+
+        input.oncancel = () => reject(new Error('File selection cancelled'))
+
+        document.body.appendChild(input)
+        input.click()
+        document.body.removeChild(input)
+    })
+}

--- a/src/pages/app/components/Option/export-import.tsx
+++ b/src/pages/app/components/Option/export-import.tsx
@@ -42,7 +42,7 @@ export async function importSettings(jsonString: string): Promise<void> {
     }
 
     // Validate the imported settings structure
-    const validatedSettings = validateAndMergeSettings(importData.settings)
+    const validatedSettings = await validateAndMergeSettings(importData.settings)
 
     // Set the imported settings
     await optionHolder.set(validatedSettings)
@@ -51,8 +51,9 @@ export async function importSettings(jsonString: string): Promise<void> {
 /**
  * Validate imported settings and merge with defaults to ensure all required fields exist
  */
-function validateAndMergeSettings(importedSettings: Partial<timer.option.AllOption>): timer.option.AllOption {
-    const defaults = defaultOption()
+async function validateAndMergeSettings(importedSettings: Partial<timer.option.AllOption>): Promise<timer.option.AllOption> {
+    // Get current user settings as defaults instead of default options
+    const defaults = await optionHolder.get()
 
     // Merge imported settings with defaults, giving preference to imported values
     const mergedSettings: timer.option.AllOption = {

--- a/src/pages/app/components/Option/style.sass
+++ b/src/pages/app/components/Option/style.sass
@@ -9,13 +9,18 @@
     // Keep the reset button top-right
     .el-tabs__nav
         float: none !important
-        #tab-reset
+        #tab-reset, #tab-export, #tab-import
             position: absolute
-            right: 0px
-            // Optimize the reset button
+            // Optimize the buttons
             .el-icon
                 top: 2px
                 padding-inline-end: 4px
+        #tab-reset
+            right: 0px
+        #tab-export
+            right: 120px
+        #tab-import
+            right: 260px
     .el-tabs__item
         font-size: 16px
         height: 43px

--- a/src/pages/app/components/Option/style.sass
+++ b/src/pages/app/components/Option/style.sass
@@ -18,9 +18,9 @@
         #tab-reset
             right: 0px
         #tab-export
-            right: 120px
+            right: 76px
         #tab-import
-            right: 260px
+            right: 112px
     .el-tabs__item
         font-size: 16px
         height: 43px


### PR DESCRIPTION
This PR adds functionality to export and import all application settings to/from JSON files, with improved UI positioning that groups action buttons together.

Points to note

Rather than implementing separate export/import for each settings category, this approach exports all settings together for several key reasons:

**Simplified Maintenance**: Managing a single comprehensive export/import system is far easier than maintaining 6+ separate export mechanisms for each settings category
**User Experience**: Users typically want to backup their entire configuration when switching devices or sharing setups, not individual pieces
**Data Integrity**: Ensures all related settings are kept together, preventing configuration conflicts from partial imports
**Implementation Efficiency**: Single validation, single file format, and unified error handling rather than duplicating logic across multiple modules