### PR TITLE
实现类似LeechBlock的子页面白名单功能

### DIFF
--- a/src/util/limit.ts
+++ b/src/util/limit.ts
@@ -18,12 +18,32 @@ const matchUrl = (cond: string, url: string): boolean => {
     return new RegExp(`^.*//${cond.split('*').join('.*')}`).test(url)
 }
 
+// 重写 matches，支持排除规则（+开头）
 export function matches(cond: timer.limit.Item['cond'], url: string): boolean {
-    return cond.some(c => matchUrl(c, url))
+    // 1. 分离「排除规则（+开头）」和「普通规则」
+    const excludeRules = cond
+        .filter(rule => rule.startsWith('+'))
+        .map(rule => rule.slice(1)) // 去掉开头的 "+"（如 "+github.com/KHDKR" → "github.com/KHDKR"）
+
+    const normalRules = cond.filter(rule => !rule.startsWith('+'))
+
+    // 2. 优先判断排除规则：只要命中一个，直接返回 false（排除规则优先级最高）
+    const isExcluded = excludeRules.some(excludeRule => matchUrl(excludeRule, url))
+    if (isExcluded) return false
+
+    // 3. 再判断普通规则：命中一个即可返回 true
+    return normalRules.some(normalRule => matchUrl(normalRule, url))
 }
 
+// 同步修改 matchCond（依赖 matchUrl，自动适配新逻辑）
+// 功能：返回所有匹配的规则（排除规则不会被返回，因为优先过滤了）
 export function matchCond(cond: timer.limit.Item['cond'], url: string): string[] {
-    return cond.filter(c => matchUrl(c, url))
+    const excludeRulePrefixes = new Set(cond.filter(r => r.startsWith('+')).map(r => r.slice(1)))
+    // 返回匹配的普通规则（排除规则不参与返回）
+    return cond.filter(rule => {
+        if (rule.startsWith('+')) return false // 排除规则不加入结果
+        return matchUrl(rule, url) && !excludeRulePrefixes.has(rule)
+    })
 }
 
 export const meetLimit = (limit: number | undefined, value: number | undefined): boolean => {

--- a/test/util/limit.test.ts
+++ b/test/util/limit.test.ts
@@ -24,6 +24,7 @@ describe('util/limit', () => {
         expect(matches(cond, 'http://t.bilibili.com/')).toBe(true)
         expect(matches(cond, 'https://www.bilibili.com/video/BV3527/')).toBe(true)
     })
+    
     test('matchCond', () => {
         const cond = ['www.baidu.com', '*.google.com', 'github.com/sheepzh', 'github.com','+www.bilibili.com/cheese','*.bilibili.com*']
         expect(matchCond(cond, 'http://www.baidu.com')).toEqual(['www.baidu.com'])

--- a/test/util/limit.test.ts
+++ b/test/util/limit.test.ts
@@ -13,19 +13,24 @@ describe('util/limit', () => {
     })
 
     test('matches', () => {
-        const cond = ['www.baidu.com', '*.google.com', 'github.com/sheepzh']
+        const cond = ['www.baidu.com', '*.google.com', 'github.com', '+github.com/KHDKR','+www.bilibili.com/cheese','*.bilibili.com*']
 
         expect(matches(cond, 'https://www.baidu.com')).toBe(true)
         expect(matches(cond, 'http://hk.google.com')).toBe(true)
         expect(matches(cond, 'http://github.com/sheepzh/timer')).toBe(true)
-        expect(matches(cond, 'http://github.com')).toBe(false)
+        expect(matches(cond, 'http://github.com/KHDKR')).toBe(false)
+        expect(matches(cond, 'http://www.bilibili.com/cheese/list')).toBe(false)
+        expect(matches(cond, 'http://t.bilibili.com/')).toBe(true)
+        expect(matches(cond, 'https://www.bilibili.com/video/BV3527/')).toBe(true)
     })
 
     test('matchCond', () => {
-        const cond = ['www.baidu.com', '*.google.com', 'github.com/sheepzh', 'github.com']
+        const cond = ['www.baidu.com', '*.google.com', 'github.com/sheepzh', 'github.com','+www.bilibili.com/cheese','*.bilibili.com*']
         expect(matchCond(cond, 'http://www.baidu.com')).toEqual(['www.baidu.com'])
         expect(matchCond(cond, 'https://github.com/sheepzh/time-tracker-for-browser')).toEqual(['github.com/sheepzh', 'github.com'])
         expect(matchCond(cond, 'https://www.github.com')).toEqual([])
+        expect(matchCond(cond, 'https://www.bilibili.com/cheese/list')).toEqual([])
+        expect(matchCond(cond, 'https://www.bilibili.com/vedio')).toEqual(['*.bilibili.com*'])
     })
 
     test('meetLimit', () => {

--- a/test/util/limit.test.ts
+++ b/test/util/limit.test.ts
@@ -13,17 +13,17 @@ describe('util/limit', () => {
     })
 
     test('matches', () => {
-        const cond = ['www.baidu.com', '*.google.com', 'github.com', '+github.com/KHDKR','+www.bilibili.com/cheese','*.bilibili.com*']
+        const cond = ['www.baidu.com', '*.google.com', 'github.com/sheepzh', '+github.com/sheepzh/timer','+www.bilibili.com/cheese','*.bilibili.com*']
 
         expect(matches(cond, 'https://www.baidu.com')).toBe(true)
         expect(matches(cond, 'http://hk.google.com')).toBe(true)
-        expect(matches(cond, 'http://github.com/sheepzh/timer')).toBe(true)
-        expect(matches(cond, 'http://github.com/KHDKR')).toBe(false)
+        expect(matches(cond, 'http://github.com/sheepzh/poetry')).toBe(true)
+        expect(matches(cond, 'http://github.com/sheepzh/timer')).toBe(false)
+        expect(matches(cond, 'http://github.com/sheepzh/timer/test')).toBe(false)
         expect(matches(cond, 'http://www.bilibili.com/cheese/list')).toBe(false)
         expect(matches(cond, 'http://t.bilibili.com/')).toBe(true)
         expect(matches(cond, 'https://www.bilibili.com/video/BV3527/')).toBe(true)
     })
-
     test('matchCond', () => {
         const cond = ['www.baidu.com', '*.google.com', 'github.com/sheepzh', 'github.com','+www.bilibili.com/cheese','*.bilibili.com*']
         expect(matchCond(cond, 'http://www.baidu.com')).toEqual(['www.baidu.com'])


### PR DESCRIPTION
修改matches和matchCond函数以支持类似LeechBlock的排除方法，即以+开头的规则作为白名单规则，以排除相应的子页面，功能基本实现，但是目前在扩展内的时间测试界面会有问题，不确定是哪个函数的问题
<img width="692" height="325" alt="image" src="https://github.com/user-attachments/assets/0e014622-4cde-435e-ae44-4c0138afceb3" />
<img width="1326" height="272" alt="image" src="https://github.com/user-attachments/assets/cf6e29f3-a814-4c83-9d21-9306171f1437" />
