### PR TITLE
fix: refresh URL limits on SPA route changes

### DIFF
--- a/examples/host/home/index.html
+++ b/examples/host/home/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+
+<body>
+    <div>Time Tracker test page — home</div>
+</body>
+
+</html>

--- a/src/content-script/index.ts
+++ b/src/content-script/index.ts
@@ -54,15 +54,14 @@ async function main() {
 
     // Execute only one time for each dom
     if (getOrSetFlag()) return
-    if (!host) return
-
-    const isWhitelist = await trySendMsg2Runtime('whitelist.contain', { host, url })
-    if (isWhitelist) return
+    if (!host || !url) return
 
     void initLocale()
-    void printInfo(host)
+    const isWhitelist = await trySendMsg2Runtime('whitelist.contain', { host, url })
     await processLimit(url, dispatcher)
+    if (isWhitelist) return
 
+    void printInfo(host)
     processTimeline()
 
     // Increase visit count at the end

--- a/src/content-script/limit/index.ts
+++ b/src/content-script/limit/index.ts
@@ -1,16 +1,32 @@
+import { trySendMsg2Runtime } from '@api/sw/common'
 import { getOption } from '@api/sw/option'
+import LocationWatcher from '../location-watcher'
 import Dispatcher from '../dispatcher'
-import ModalInstance from "./modal/instance"
+import ModalInstance from './modal/instance'
 import MessageAdaptor from './processor/message-adaptor'
-import PeriodProcessor from "./processor/period-processor"
-import VisitProcessor from "./processor/visit-processor"
+import PeriodProcessor from './processor/period-processor'
+import VisitProcessor from './processor/visit-processor'
 import Reminder from './reminder'
 import type { ModalContext, Processor } from './types'
+
+const getHost = (url: string): string | undefined => {
+    try {
+        return new URL(url).host
+    } catch {
+        return undefined
+    }
+}
+
+const isWhitelisted = async (url: string): Promise<boolean> => {
+    const host = getHost(url)
+    if (!host) return true
+    return !!await trySendMsg2Runtime('whitelist.contain', { host, url })
+}
 
 export default async function processLimit(url: string, dispatcher: Dispatcher) {
     const { limitDelayDuration: delayDuration } = await getOption()
     const modal = new ModalInstance(url)
-    const context: ModalContext = { modal, url }
+    const context: ModalContext = { modal, url: '' }
 
     const messageAdaptor = new MessageAdaptor(context, delayDuration)
     const visitProcessor = new VisitProcessor(context, delayDuration)
@@ -22,11 +38,34 @@ export default async function processLimit(url: string, dispatcher: Dispatcher) 
     ]
     await Promise.all(processors.map(p => p.init()))
 
+    let active = false
+    let refreshId = 0
+    const refreshUrl = async (nextUrl: string): Promise<void> => {
+        if (!nextUrl) return
+        const currentRefreshId = ++refreshId
+        const urlChanged = nextUrl !== context.url
+        context.url = nextUrl
+        modal.setUrl(nextUrl)
+        active = false
+        processors.forEach(p => p.clear(urlChanged))
+        const whitelisted = await isWhitelisted(nextUrl)
+        if (currentRefreshId !== refreshId || whitelisted) return
+        active = true
+        await Promise.all(processors.map(p => p.onLimitChanged()))
+        if (currentRefreshId !== refreshId) return
+    }
+
+    await refreshUrl(url)
+    new LocationWatcher(url, nextUrl => void refreshUrl(nextUrl)).init()
+
     const reminder = new Reminder()
 
     dispatcher
-        .register('limitChanged', () => void processors.forEach(p => p.onLimitChanged()))
-        .register('limitTimeMeet', items => void messageAdaptor.onLimitTimeMeet(items))
+        .register('limitChanged', () => void refreshUrl(context.url))
+        .register('limitTimeMeet', items => {
+            if (active) void messageAdaptor.onLimitTimeMeet(items)
+            return undefined
+        })
         .register('limitReminder', data => void reminder.show(data))
         .register('askVisitHit', ruleId => modal.reasons.some(r => r.type === 'VISIT' && ruleId === r.id))
         .registerAudibleChange(visitProcessor.tracker)

--- a/src/content-script/limit/index.ts
+++ b/src/content-script/limit/index.ts
@@ -43,16 +43,16 @@ export default async function processLimit(url: string, dispatcher: Dispatcher) 
     const refreshUrl = async (nextUrl: string): Promise<void> => {
         if (!nextUrl) return
         const currentRefreshId = ++refreshId
-        const urlChanged = nextUrl !== context.url
+        const prevUrl = context.url
         context.url = nextUrl
         modal.setUrl(nextUrl)
         active = false
-        processors.forEach(p => p.clear(urlChanged))
         const whitelisted = await isWhitelisted(nextUrl)
-        if (currentRefreshId !== refreshId || whitelisted) return
-        active = true
-        await Promise.all(processors.map(p => p.onLimitChanged()))
         if (currentRefreshId !== refreshId) return
+
+        await Promise.all(processors.map(p => p.onUrlRefreshed({ prevUrl, nextUrl, whitelisted })))
+        if (currentRefreshId !== refreshId) return
+        active = !whitelisted
     }
 
     await refreshUrl(url)

--- a/src/content-script/limit/modal/components/Footer.tsx
+++ b/src/content-script/limit/modal/components/Footer.tsx
@@ -15,8 +15,8 @@ import { useApp, useRule } from '../context'
 const _default = defineComponent(() => {
     const { reason, visitTime: currVisitTime, bridge, url, delayDuration } = useApp()
 
-    const analysisUrl = getAppPageUrl(APP_ANALYSIS_ROUTE, { url } satisfies AppAnalysisQuery)
-    const ruleUrl = getAppPageUrl(APP_LIMIT_ROUTE, { url: encodeURI(url) } satisfies AppLimitQuery)
+    const analysisUrl = computed(() => getAppPageUrl(APP_ANALYSIS_ROUTE, { url: url.value } satisfies AppAnalysisQuery))
+    const ruleUrl = computed(() => getAppPageUrl(APP_LIMIT_ROUTE, { url: encodeURI(url.value) } satisfies AppLimitQuery))
 
     const rule = useRule()
     const showDelay = computed(() => {
@@ -56,7 +56,7 @@ const _default = defineComponent(() => {
 
     return () => (
         <Flex gap={10} marginBottom={60} justify='center'>
-            <a target='_blank' href={analysisUrl}>
+            <a target='_blank' href={analysisUrl.value}>
                 <ElButton round icon={Trend} type="success">
                     {t(msg => msg.menu.siteAnalysis)}
                 </ElButton>
@@ -68,7 +68,7 @@ const _default = defineComponent(() => {
             >
                 {t(msg => msg.modal.delay, { n: delayDuration.value })}
             </ElButton>
-            <a target='_blank' href={ruleUrl}>
+            <a target='_blank' href={ruleUrl.value}>
                 <ElButton round icon={Timer}>
                     {t(msg => msg.modal.ruleDetail)}
                 </ElButton>

--- a/src/content-script/limit/modal/components/Reason.tsx
+++ b/src/content-script/limit/modal/components/Reason.tsx
@@ -51,7 +51,7 @@ const TimeDescriptions = defineComponent<DescriptionProps>(props => {
 
     return () => (
         <ElDescriptions border column={1} size={size.value} style={style.value}>
-            {renderBaseItems(rule.value, url)}
+            {renderBaseItems(rule.value, url.value)}
             <ElDescriptionsItem label={props.ruleLabel} labelAlign="right">
                 <Flex gap={5} width={200}>
                     <ElTag v-show={!!props.time}>{formatPeriodCommon((props.time ?? 0) * MILL_PER_SECOND)}</ElTag>
@@ -113,7 +113,7 @@ const _default = defineComponent(() => {
                 dataLabel={t(msg => msg.calendar.range.thisWeek)}
             />
             <ElDescriptions v-show={type.value === 'VISIT'} border column={1} style={style.value} size={size.value}>
-                {renderBaseItems(rule.value, url)}
+                {renderBaseItems(rule.value, url.value)}
                 <ElDescriptionsItem label={t(msg => msg.limit.item.visitTime)} labelAlign="right">
                     {formatPeriodCommon((rule.value?.visitTime ?? 0) * MILL_PER_SECOND) || '-'}
                 </ElDescriptionsItem>
@@ -127,7 +127,7 @@ const _default = defineComponent(() => {
                 </ElDescriptionsItem>
             </ElDescriptions>
             <ElDescriptions v-show={type.value === 'PERIOD'} border column={1} style={style.value} size={size.value}>
-                {renderBaseItems(rule.value, url)}
+                {renderBaseItems(rule.value, url.value)}
                 <ElDescriptionsItem label={t(msg => msg.shared.limit.period)} labelAlign="right">
                     {rule.value?.periods?.length
                         ? <div>

--- a/src/content-script/limit/modal/context.ts
+++ b/src/content-script/limit/modal/context.ts
@@ -12,17 +12,20 @@ type AppContext = {
     reason: ShallowRef<LimitReasonData | undefined>
     visitTime: ShallowRef<number>
     bridge: ModalBridge
-    url: string
+    url: Ref<string>
     delayDuration: Ref<number>
 }
 
 export const provideApp = (app: App<Element>, bridge: ModalBridge, url: string) => {
     const reason = ref<LimitReasonData | undefined>()
     const visitTime = ref(0)
+    const currentUrl = ref(url)
     const delayDuration = ref(5)
     getOption().then(({ limitDelayDuration }) => delayDuration.value = limitDelayDuration).catch(() => { })
 
-    bridge.register('reason', data => { reason.value = data })
+    bridge
+        .register('reason', data => { reason.value = data })
+        .register('url', data => { currentUrl.value = data })
 
     const updateVisitTime = async () => {
         bridge.request('visitTime', undefined)
@@ -40,7 +43,7 @@ export const provideApp = (app: App<Element>, bridge: ModalBridge, url: string) 
         _unmount()
     }
 
-    app.provide<AppContext>(GLOBAL_KEY, { reason, visitTime, bridge, url, delayDuration })
+    app.provide<AppContext>(GLOBAL_KEY, { reason, visitTime, bridge, url: currentUrl, delayDuration })
 }
 
 export const useApp = () => inject(GLOBAL_KEY) as AppContext

--- a/src/content-script/limit/modal/instance.ts
+++ b/src/content-script/limit/modal/instance.ts
@@ -84,6 +84,12 @@ class ModalInstance implements MaskModal {
             .register('delay', () => this.delayHandlers.forEach(handler => handler()))
     }
 
+    setUrl(url: string): void {
+        if (url === this.url) return
+        this.url = url
+        this.iframe?.contentWindow && this.bridge.request('url', url).catch(() => { })
+    }
+
     addReason(...reasons2Add: LimitReason[]): void {
         reasons2Add = reasons2Add.filter(r => !this.reasons.some(reason => isSameReason(r, reason)))
         if (!reasons2Add.length) return
@@ -141,6 +147,9 @@ class ModalInstance implements MaskModal {
             const exist = this.rootElement ?? document.querySelector(TAG_NAME) as RootElement
             if (exist) {
                 this.rootElement = exist
+                if (!document.body.contains(exist)) {
+                    document.body.appendChild(exist)
+                }
                 return exist.shadowRoot
             }
             this.rootElement = createRootElement()
@@ -157,6 +166,8 @@ class ModalInstance implements MaskModal {
     private async show(reason: LimitReason) {
         if (!this.rootElement) {
             await this.init()
+        } else if (!document.body.contains(this.rootElement)) {
+            document.body.appendChild(this.rootElement)
         }
         await exitFullscreen()
         pauseAllVideo()

--- a/src/content-script/limit/modal/types.ts
+++ b/src/content-script/limit/modal/types.ts
@@ -10,6 +10,7 @@ type BridgeRegistry =
     & MakeRegistry<'reason', LimitReasonData | undefined, void>
     & MakeRegistry<'visitTime', void, number>
     & MakeRegistry<'delay', void, void>
+    & MakeRegistry<'url', string, void>
 
 export type BridgeCode = keyof BridgeRegistry
 export type BridgeRequest<C extends BridgeCode> = BridgeRegistry[C]['req']

--- a/src/content-script/limit/processor/message-adaptor.ts
+++ b/src/content-script/limit/processor/message-adaptor.ts
@@ -1,6 +1,6 @@
 import { trySendMsg2Runtime } from '@api/sw/common'
 import { hasDailyLimited, hasWeeklyLimited, matches } from "@util/limit"
-import type { LimitReason, ModalContext, Processor } from '../types'
+import type { LimitReason, ModalContext, Processor, UrlRefreshContext } from '../types'
 
 const cvtItem2AddReason = (item: tt4b.limit.Item, delayDuration: number): LimitReason[] => {
     const { cond, allowDelay, id, delayCount, weeklyDelayCount } = item
@@ -13,10 +13,6 @@ const cvtItem2AddReason = (item: tt4b.limit.Item, delayDuration: number): LimitR
 class MessageAdaptor implements Processor {
     constructor(private readonly context: ModalContext, private readonly delayDuration: number) { }
 
-    onLimitChanged(): Promise<void> {
-        return this.initRules()
-    }
-
     onLimitTimeMeet(items: tt4b.limit.Item[]): void {
         if (!items.length) return
         items.filter(({ cond }) => matches(cond, this.context.url))
@@ -28,13 +24,21 @@ class MessageAdaptor implements Processor {
         this.context.modal.addDelayHandler(() => void this.initRules())
     }
 
-    clear(_urlChanged?: boolean): void {
+    async onUrlRefreshed({ nextUrl, whitelisted }: UrlRefreshContext): Promise<void> {
         this.context.modal.removeReasonsByType('DAILY', 'WEEKLY')
+        if (whitelisted) return
+        await this.fetchLimitedRules(nextUrl)
     }
 
     async initRules(): Promise<void> {
-        const url = this.context.url
-        this.clear()
+        await this.onUrlRefreshed({
+            prevUrl: this.context.url,
+            nextUrl: this.context.url,
+            whitelisted: false,
+        })
+    }
+
+    private async fetchLimitedRules(url: string): Promise<void> {
         const limitedRules = await trySendMsg2Runtime('limit.list', { limited: true, effective: true, url })
         if (url !== this.context.url || !limitedRules?.length) return
 

--- a/src/content-script/limit/processor/message-adaptor.ts
+++ b/src/content-script/limit/processor/message-adaptor.ts
@@ -13,8 +13,8 @@ const cvtItem2AddReason = (item: tt4b.limit.Item, delayDuration: number): LimitR
 class MessageAdaptor implements Processor {
     constructor(private readonly context: ModalContext, private readonly delayDuration: number) { }
 
-    onLimitChanged(): void {
-        this.initRules()
+    onLimitChanged(): Promise<void> {
+        return this.initRules()
     }
 
     onLimitTimeMeet(items: tt4b.limit.Item[]): void {
@@ -25,14 +25,18 @@ class MessageAdaptor implements Processor {
     }
 
     async init(): Promise<void> {
-        this.initRules()
-        this.context.modal.addDelayHandler(() => this.initRules())
+        this.context.modal.addDelayHandler(() => void this.initRules())
+    }
+
+    clear(_urlChanged?: boolean): void {
+        this.context.modal.removeReasonsByType('DAILY', 'WEEKLY')
     }
 
     async initRules(): Promise<void> {
-        this.context.modal.removeReasonsByType('DAILY', 'WEEKLY')
-        const limitedRules = await trySendMsg2Runtime('limit.list', { limited: true, effective: true, url: this.context.url })
-        if (!limitedRules?.length) return
+        const url = this.context.url
+        this.clear()
+        const limitedRules = await trySendMsg2Runtime('limit.list', { limited: true, effective: true, url })
+        if (url !== this.context.url || !limitedRules?.length) return
 
         const reasons = limitedRules.flatMap(item => cvtItem2AddReason(item, this.delayDuration))
         this.context.modal.addReason(...reasons)

--- a/src/content-script/limit/processor/period-processor.ts
+++ b/src/content-script/limit/processor/period-processor.ts
@@ -1,7 +1,7 @@
 import { trySendMsg2Runtime } from '@api/sw/common'
 import { date2Idx } from "@util/limit"
 import { MILL_PER_SECOND } from "@util/time"
-import type { LimitReason, ModalContext, Processor } from '../types'
+import type { LimitReason, ModalContext, Processor, UrlRefreshContext } from '../types'
 
 function processRule(rule: tt4b.limit.Rule, nowSeconds: number, context: ModalContext): ReturnType<typeof setTimeout>[] {
     const { cond, periods, id } = rule
@@ -28,24 +28,17 @@ class PeriodProcessor implements Processor {
 
     constructor(private readonly context: ModalContext) { }
 
-    async onLimitChanged(): Promise<void> {
-        await this.initRules()
-    }
-
     init(): void {
     }
 
-    clear(_urlChanged?: boolean): void {
+    async onUrlRefreshed({ nextUrl, whitelisted }: UrlRefreshContext): Promise<void> {
         this.timers.forEach(clearTimeout)
         this.timers = []
         this.context.modal.removeReasonsByType('PERIOD')
-    }
+        if (whitelisted) return
 
-    private async initRules(): Promise<void> {
-        const url = this.context.url
-        this.clear()
-        const rules = await trySendMsg2Runtime('limit.list', { effective: true, url }) ?? []
-        if (url !== this.context.url) return
+        const rules = await trySendMsg2Runtime('limit.list', { effective: true, url: nextUrl }) ?? []
+        if (nextUrl !== this.context.url) return
         const nowSeconds = date2Idx(new Date())
         this.timers = rules.flatMap(r => processRule(r, nowSeconds, this.context))
     }

--- a/src/content-script/limit/processor/period-processor.ts
+++ b/src/content-script/limit/processor/period-processor.ts
@@ -10,7 +10,7 @@ function processRule(rule: tt4b.limit.Rule, nowSeconds: number, context: ModalCo
         const [s, e] = p
         const startSeconds = s * 60
         const endSeconds = (e + 1) * 60
-        const reason: LimitReason = { id, cond, type: "PERIOD" }
+        const reason: LimitReason = { id, cond, type: 'PERIOD' }
         const timers: ReturnType<typeof setTimeout>[] = []
         if (nowSeconds < startSeconds) {
             timers.push(setTimeout(() => context.modal.addReason(reason), (startSeconds - nowSeconds) * MILL_PER_SECOND))
@@ -29,15 +29,23 @@ class PeriodProcessor implements Processor {
     constructor(private readonly context: ModalContext) { }
 
     async onLimitChanged(): Promise<void> {
-        await this.init()
+        await this.initRules()
     }
 
-    async init(): Promise<void> {
-        // Clear first
-        this.timers.forEach(clearTimeout)
-        this.context.modal.removeReasonsByType("PERIOD")
+    init(): void {
+    }
 
-        const rules = await trySendMsg2Runtime('limit.list', { effective: true, url: this.context.url }) ?? []
+    clear(_urlChanged?: boolean): void {
+        this.timers.forEach(clearTimeout)
+        this.timers = []
+        this.context.modal.removeReasonsByType('PERIOD')
+    }
+
+    private async initRules(): Promise<void> {
+        const url = this.context.url
+        this.clear()
+        const rules = await trySendMsg2Runtime('limit.list', { effective: true, url }) ?? []
+        if (url !== this.context.url) return
         const nowSeconds = date2Idx(new Date())
         this.timers = rules.flatMap(r => processRule(r, nowSeconds, this.context))
     }

--- a/src/content-script/limit/processor/visit-processor.ts
+++ b/src/content-script/limit/processor/visit-processor.ts
@@ -1,7 +1,7 @@
 import { trySendMsg2Runtime } from '@api/sw/common'
 import NormalTracker from "@cs/tracker/normal"
 import { MILL_PER_MINUTE, MILL_PER_SECOND } from "@util/time"
-import type { ModalContext, Processor } from '../types'
+import type { ModalContext, Processor, UrlRefreshContext } from '../types'
 
 class VisitProcessor implements Processor {
     private focusTime: number = 0
@@ -13,10 +13,6 @@ class VisitProcessor implements Processor {
         this.tracker = new NormalTracker({
             onReport: data => this.handleTracker(data),
         })
-    }
-
-    onLimitChanged(): Promise<void> {
-        return this.initRules()
     }
 
     private hasLimited(rule: tt4b.limit.Rule): boolean {
@@ -43,26 +39,23 @@ class VisitProcessor implements Processor {
         })
     }
 
-    private async initRules() {
-        const url = this.context.url
-        this.clear()
-        const rules = await trySendMsg2Runtime('limit.list', { effective: true, url }) ?? []
-        if (url !== this.context.url) return
-        this.rules = rules
-    }
-
     async init(): Promise<void> {
         this.tracker.init()
         this.context.modal.addDelayHandler(() => this.processDelay())
     }
 
-    clear(urlChanged?: boolean): void {
+    async onUrlRefreshed({ prevUrl, nextUrl, whitelisted }: UrlRefreshContext): Promise<void> {
         this.rules = []
-        if (urlChanged) {
+        if (prevUrl !== nextUrl) {
             this.focusTime = 0
             this.delayCount = 0
         }
         this.context.modal.removeReasonsByType('VISIT')
+        if (whitelisted) return
+
+        const rules = await trySendMsg2Runtime('limit.list', { effective: true, url: nextUrl }) ?? []
+        if (nextUrl !== this.context.url) return
+        this.rules = rules
     }
 
     private processDelay() {

--- a/src/content-script/limit/processor/visit-processor.ts
+++ b/src/content-script/limit/processor/visit-processor.ts
@@ -15,8 +15,8 @@ class VisitProcessor implements Processor {
         })
     }
 
-    onLimitChanged(): void {
-        this.initRules()
+    onLimitChanged(): Promise<void> {
+        return this.initRules()
     }
 
     private hasLimited(rule: tt4b.limit.Rule): boolean {
@@ -35,7 +35,7 @@ class VisitProcessor implements Processor {
             this.context.modal.addReason({
                 id,
                 cond,
-                type: "VISIT",
+                type: 'VISIT',
                 allowDelay,
                 delayCount: this.delayCount,
                 getVisitTime: () => this.focusTime,
@@ -44,19 +44,30 @@ class VisitProcessor implements Processor {
     }
 
     private async initRules() {
-        this.rules = await trySendMsg2Runtime("limit.list", { effective: true, url: this.context.url }) ?? []
-        this.context.modal.removeReasonsByType("VISIT")
+        const url = this.context.url
+        this.clear()
+        const rules = await trySendMsg2Runtime('limit.list', { effective: true, url }) ?? []
+        if (url !== this.context.url) return
+        this.rules = rules
     }
 
     async init(): Promise<void> {
         this.tracker.init()
-        this.initRules()
         this.context.modal.addDelayHandler(() => this.processDelay())
+    }
+
+    clear(urlChanged?: boolean): void {
+        this.rules = []
+        if (urlChanged) {
+            this.focusTime = 0
+            this.delayCount = 0
+        }
+        this.context.modal.removeReasonsByType('VISIT')
     }
 
     private processDelay() {
         this.delayCount++
-        this.context.modal.removeReasonsByType("VISIT")
+        this.context.modal.removeReasonsByType('VISIT')
     }
 }
 

--- a/src/content-script/limit/types.ts
+++ b/src/content-script/limit/types.ts
@@ -22,8 +22,13 @@ export type ModalContext = {
     modal: MaskModal
 }
 
+export type UrlRefreshContext = {
+    prevUrl: string
+    nextUrl: string
+    whitelisted: boolean
+}
+
 export interface Processor {
     init(): Awaitable<void>
-    onLimitChanged(): Awaitable<void>
-    clear(urlChanged?: boolean): void
+    onUrlRefreshed(ctx: UrlRefreshContext): Awaitable<void>
 }

--- a/src/content-script/limit/types.ts
+++ b/src/content-script/limit/types.ts
@@ -10,6 +10,7 @@ export type LimitReason =
 export interface MaskModal {
     readonly reasons: LimitReason[]
 
+    setUrl(url: string): void
     addReason(...reasons: LimitReason[]): void
     removeReason(...reasons: LimitReason[]): void
     removeReasonsByType(...types: tt4b.limit.ReasonType[]): void
@@ -23,5 +24,6 @@ export type ModalContext = {
 
 export interface Processor {
     init(): Awaitable<void>
-    onLimitChanged(): void
+    onLimitChanged(): Awaitable<void>
+    clear(urlChanged?: boolean): void
 }

--- a/src/content-script/location-watcher.ts
+++ b/src/content-script/location-watcher.ts
@@ -1,0 +1,64 @@
+type UrlChangeHandler = (url: string, prevUrl: string) => void
+
+class LocationWatcher {
+    private url: string
+    private timer: number | undefined
+    private initialized = false
+    private originalPushState: History['pushState'] | undefined
+    private originalReplaceState: History['replaceState'] | undefined
+    private readonly handleChangeBound = this.handleChange.bind(this)
+
+    constructor(url: string, private readonly handler: UrlChangeHandler, private readonly interval = 800) {
+        this.url = url
+    }
+
+    init(): void {
+        if (this.initialized) return
+        this.initialized = true
+
+        window.addEventListener('popstate', this.handleChangeBound)
+        window.addEventListener('hashchange', this.handleChangeBound)
+        this.timer = window.setInterval(this.handleChangeBound, this.interval)
+
+        this.originalPushState = history.pushState
+        this.originalReplaceState = history.replaceState
+
+        history.pushState = (...args: Parameters<History['pushState']>) => {
+            this.originalPushState!.apply(history, args)
+            this.handleChangeBound()
+        }
+        history.replaceState = (...args: Parameters<History['replaceState']>) => {
+            this.originalReplaceState!.apply(history, args)
+            this.handleChangeBound()
+        }
+    }
+
+    dispose(): void {
+        if (!this.initialized) return
+        this.initialized = false
+
+        window.removeEventListener('popstate', this.handleChangeBound)
+        window.removeEventListener('hashchange', this.handleChangeBound)
+        this.timer && clearInterval(this.timer)
+        this.timer = undefined
+
+        if (this.originalPushState) {
+            history.pushState = this.originalPushState
+            this.originalPushState = undefined
+        }
+        if (this.originalReplaceState) {
+            history.replaceState = this.originalReplaceState
+            this.originalReplaceState = undefined
+        }
+    }
+
+    private handleChange(): void {
+        const url = window.location.href
+        if (!url || url === this.url) return
+        const prevUrl = this.url
+        this.url = url
+        this.handler(url, prevUrl)
+    }
+}
+
+export default LocationWatcher

--- a/src/pages/app/components/Option/categories/Backup/Clear/index.tsx
+++ b/src/pages/app/components/Option/categories/Backup/Clear/index.tsx
@@ -12,7 +12,7 @@ import { t } from '@app/locale'
 import { Delete } from "@element-plus/icons-vue"
 import { BIRTHDAY, formatTimeYMD } from '@util/time'
 import { ElButton } from "element-plus"
-import { defineComponent } from "vue"
+import { defineComponent, ref } from "vue"
 import ClientTable from '../ClientTable'
 import Step2 from './Step2'
 import type { ClearForm, StatResult } from './types'
@@ -38,7 +38,8 @@ async function fetchStatResult(client: tt4b.backup.Client): Promise<StatResult> 
 }
 
 const _default = defineComponent(() => {
-    const { step, form, open } = initDialogSopContext<ClearForm>({
+    const tableKey = ref(0)
+    const { step, form, open: openSop } = initDialogSopContext<ClearForm>({
         stepCount: STEP_TITLES.length,
         init: () => ({}),
         onNext: async ({ form }) => {
@@ -53,10 +54,14 @@ const _default = defineComponent(() => {
             if (errMsg) throw new Error(errMsg)
         },
     })
+    const open = () => {
+        tableKey.value++
+        openSop()
+    }
 
 
     return () => <>
-        <ElButton type="danger" icon={Delete} onClick={() => open()}>
+        <ElButton type="danger" icon={Delete} onClick={open}>
             {t(msg => msg.option.backup.clear.btn)}
         </ElButton>
         <DialogSop
@@ -64,7 +69,9 @@ const _default = defineComponent(() => {
             finishButton={{ type: 'danger', text: t(msg => msg.option.backup.clear.btn) }}
             stepTitles={STEP_TITLES}
         >
-            {step.value === 0 ? <ClientTable onSelect={c => form.client = c} /> : <Step2 />}
+            {step.value === 0
+                ? <ClientTable key={tableKey.value} onSelect={c => form.client = c} />
+                : <Step2 />}
         </DialogSop>
     </>
 })

--- a/src/pages/app/components/Option/categories/Backup/ClientTable.tsx
+++ b/src/pages/app/components/Option/categories/Backup/ClientTable.tsx
@@ -6,7 +6,6 @@
  */
 
 import { allBackupClients } from "@api/sw/backup"
-import { useDialogSop } from '@app/components/common/DialogSop/context'
 import { t } from '@app/locale'
 import { cvt2LocaleTime } from '@app/util/time'
 import { Loading, RefreshRight } from "@element-plus/icons-vue"
@@ -35,10 +34,8 @@ const formatTime = (value: tt4b.backup.Client): string => {
 }
 
 const _default = defineComponent<{ onSelect: ArgCallback<tt4b.backup.Client> }>(props => {
-    const { visible } = useDialogSop()
     const { data: list, loading, refresh } = useRequest(allBackupClients, {
         defaultValue: [],
-        deps: () => visible.value,
         onError: e => ElMessage.error(e instanceof Error ? e.message : String(e ?? 'Unknown error...'))
     })
 

--- a/src/pages/app/components/Option/categories/Backup/ClientTable.tsx
+++ b/src/pages/app/components/Option/categories/Backup/ClientTable.tsx
@@ -6,6 +6,7 @@
  */
 
 import { allBackupClients } from "@api/sw/backup"
+import { useDialogSop } from '@app/components/common/DialogSop/context'
 import { t } from '@app/locale'
 import { cvt2LocaleTime } from '@app/util/time'
 import { Loading, RefreshRight } from "@element-plus/icons-vue"
@@ -34,8 +35,10 @@ const formatTime = (value: tt4b.backup.Client): string => {
 }
 
 const _default = defineComponent<{ onSelect: ArgCallback<tt4b.backup.Client> }>(props => {
+    const { visible } = useDialogSop()
     const { data: list, loading, refresh } = useRequest(allBackupClients, {
         defaultValue: [],
+        deps: () => visible.value,
         onError: e => ElMessage.error(e instanceof Error ? e.message : String(e ?? 'Unknown error...'))
     })
 

--- a/src/pages/app/components/Option/categories/Backup/Download/index.tsx
+++ b/src/pages/app/components/Option/categories/Backup/Download/index.tsx
@@ -12,7 +12,7 @@ import { t } from "@app/locale"
 import { Files } from "@element-plus/icons-vue"
 import { BIRTHDAY, formatTimeYMD } from '@util/time'
 import { ElButton } from "element-plus"
-import { defineComponent, toRaw } from "vue"
+import { defineComponent, ref, toRaw } from "vue"
 import ClientTable from '../ClientTable'
 import Step2 from './Step2'
 import type { DownloadForm } from './types'
@@ -31,7 +31,8 @@ async function fetchData(client: tt4b.backup.Client): Promise<tt4b.imported.Data
 }
 
 const _default = defineComponent(() => {
-    const { open, step, form } = initDialogSopContext<DownloadForm>({
+    const tableKey = ref(0)
+    const { open: openSop, step, form } = initDialogSopContext<DownloadForm>({
         stepCount: STEP_TITLES.length,
         init: () => ({ data: { rows: [], focus: true, time: true }, resolution: undefined }),
         onNext: async ({ form, target }) => {
@@ -49,9 +50,13 @@ const _default = defineComponent(() => {
             await importOther({ resolution, data: toRaw(data) })
         },
     })
+    const open = () => {
+        tableKey.value++
+        openSop()
+    }
 
     return () => <>
-        <ElButton type="primary" icon={Files} onClick={() => open()}>
+        <ElButton type="primary" icon={Files} onClick={open}>
             {t(msg => msg.option.backup.download.btn)}
         </ElButton>
         <DialogSop
@@ -60,7 +65,7 @@ const _default = defineComponent(() => {
             stepTitles={STEP_TITLES}
             finishButton={{ text: t(msg => msg.option.backup.download.btn) }}
         >
-            <ClientTable v-show={step.value === 0} onSelect={c => form.client = c} />
+            <ClientTable key={tableKey.value} v-show={step.value === 0} onSelect={c => form.client = c} />
             <Step2 v-show={step.value === 1} />
         </DialogSop>
     </>

--- a/src/util/limit.ts
+++ b/src/util/limit.ts
@@ -4,7 +4,8 @@ import { getWeekDay, MILL_PER_MINUTE, MILL_PER_SECOND } from "./time"
 const GLOBSTAR_TOKEN = `__GLOBSTAR${Math.random().toString(36).slice(2, 6)}__`
 
 const matchUrl = (cond: string, url: string): boolean => {
-    const pattern = cond
+    const normalizedCond = cond.length > 1 ? cond.replace(/\/$/, '') : cond
+    const pattern = normalizedCond
         .replace(/\*\*/g, GLOBSTAR_TOKEN)
         .split('*')
         .join('.*')

--- a/test-e2e/backup/common.ts
+++ b/test-e2e/backup/common.ts
@@ -12,26 +12,60 @@ const typeNames: Record<tt4b.backup.Type, string> = {
 
 const OPTION_TAB_ID = 'pane-backup'
 
-async function waitClientReady(page: Page): Promise<ElementHandle<Element> | null> {
+async function waitForNoVisibleOverlay(page: Page): Promise<void> {
     await page.waitForFunction(() => {
-        const emptyBody = document.querySelector('.el-dialog .el-table__empty-block')
-        const rows = document.querySelectorAll('.el-dialog .el-table .el-table__row')
-        return !!emptyBody || !!rows.length
-    }, { timeout: 1000 })
+        return ![...document.querySelectorAll('.el-overlay')].some(o => {
+            return window.getComputedStyle(o).display !== 'none'
+        })
+    }, { timeout: 5000 })
+}
 
-    const nextBtn = await page.waitForSelector(
-        '.el-overlay:not([style*="display: none"]) .el-dialog .el-button.el-button--primary:not([disabled])',
-        { timeout: 1000 },
-    )
+async function queryTopVisibleDialog(page: Page): Promise<ElementHandle<Element> | null> {
+    const overlays = await page.$$('.el-overlay')
+    for (const overlay of overlays.reverse()) {
+        const visible = await overlay.evaluate(el => window.getComputedStyle(el).display !== 'none')
+        if (!visible) continue
+        const dialog = await overlay.$('.el-dialog')
+        if (dialog) return dialog
+    }
+    return null
+}
+
+async function waitClientReady(page: Page): Promise<ElementHandle<Element>> {
+    await page.waitForFunction(() => {
+        const overlays = [...document.querySelectorAll('.el-overlay')].filter(o => {
+            const style = window.getComputedStyle(o)
+            return style.display !== 'none'
+        })
+        const dialog = overlays.at(-1)?.querySelector('.el-dialog')
+        if (!dialog) return false
+        const emptyBody = dialog.querySelector('.el-table__empty-block')
+        const rows = dialog.querySelectorAll('.el-table .el-table__row')
+        const tableReady = !!emptyBody || !!rows.length
+        const nextBtn = dialog.querySelector('.el-button.el-button--primary:not([disabled])')
+        return tableReady && !!nextBtn
+    }, { timeout: 5000 })
+
+    const dialog = await queryTopVisibleDialog(page)
+    const nextBtn = await dialog?.$('.el-button.el-button--primary:not([disabled])')
+    if (!nextBtn) throw new Error('Next button not found')
     return nextBtn
 }
 
 async function findCurrentClientRow(page: Page): Promise<ElementHandle<Element> | null> {
-    const table = await page.waitForSelector(
-        '.el-overlay:not([style*="display: none"]) .el-dialog .el-table',
-        { timeout: 2000 },
-    )
-    const rows = await table!.$$('.el-table__row')
+    await page.waitForFunction(() => {
+        const overlays = [...document.querySelectorAll('.el-overlay')].filter(o => {
+            const style = window.getComputedStyle(o)
+            return style.display !== 'none'
+        })
+        return !!overlays.at(-1)?.querySelector('.el-dialog .el-table')
+    }, { timeout: 5000 })
+
+    const dialog = await queryTopVisibleDialog(page)
+    const tableEl = await dialog?.$('.el-table')
+    if (!tableEl) return null
+
+    const rows = await tableEl.$$('.el-table__row')
 
     for (const row of rows) {
         const currVisible = await row.evaluate(el => {
@@ -96,8 +130,7 @@ export class BackupOptionWrapper {
 
     async assertTestInvalid() {
         const page = await this.clickButton('test')
-        // The same as mock server
-        await waitForMessage(page, 'Unauthorized')
+        await waitForMessage(page, '[401] Invalid token or no permission to access gist')
     }
 
     async assertTestValid() {
@@ -175,7 +208,9 @@ export class BackupOptionWrapper {
     }
 
     async clearData() {
-        const page = await this.clickButton('clear')
+        const page = await this.page()
+        await waitForNoVisibleOverlay(page)
+        await this.clickButton('clear')
 
         const nextBtn = await waitClientReady(page)
 

--- a/test-e2e/limit/common.ts
+++ b/test-e2e/limit/common.ts
@@ -2,12 +2,39 @@ import type { ElementHandle, Frame, Page } from "puppeteer"
 import { fillCondEditor } from "../common/cond-editor"
 import { sleep } from "../common/util"
 
+export async function waitForLimitModalHidden(page: Page, timeout = 15000): Promise<void> {
+    await page.waitForFunction(
+        () => {
+            const overlay = document.querySelector('extension-time-tracker-overlay')
+            if (!overlay) return true
+            const iframe = overlay.shadowRoot?.firstElementChild
+            return !(iframe instanceof HTMLIFrameElement)
+                || iframe.style.visibility === 'hidden'
+                || iframe.style.display === 'none'
+        },
+        { timeout },
+    )
+}
+
+export async function waitForLimitModal(page: Page, timeout = 15000): Promise<void> {
+    await page.waitForFunction(
+        () => {
+            const overlay = document.querySelector('extension-time-tracker-overlay')
+            if (!overlay) return false
+            const iframe = overlay.shadowRoot?.firstElementChild
+            return iframe instanceof HTMLIFrameElement
+                && iframe.style.visibility !== 'hidden'
+                && iframe.style.display !== 'none'
+        },
+        { timeout },
+    )
+}
+
 export async function waitForLimitFrame(page: Page, timeout = 5000): Promise<Frame> {
     return page.waitForFrame(f => f.url().includes('limit.html'), { timeout })
 }
 
-export async function isLimitModalVisible(page: Page): Promise<boolean> {
-    await page.waitForSelector('extension-time-tracker-overlay', { timeout: 3000 })
+export async function queryLimitModalVisible(page: Page): Promise<boolean> {
     return await page.evaluate(async () => {
         const overlay = document.querySelector('extension-time-tracker-overlay')
         if (!overlay) return false
@@ -16,6 +43,11 @@ export async function isLimitModalVisible(page: Page): Promise<boolean> {
             && iframe.style.visibility !== 'hidden'
             && iframe.style.display !== 'none'
     })
+}
+
+export async function isLimitModalVisible(page: Page): Promise<boolean> {
+    await page.waitForSelector('extension-time-tracker-overlay', { timeout: 3000 })
+    return await queryLimitModalVisible(page)
 }
 
 export async function createLimitRule(rule: tt4b.limit.Rule, page: Page) {

--- a/test-e2e/limit/daily-limit.test.ts
+++ b/test-e2e/limit/daily-limit.test.ts
@@ -1,6 +1,6 @@
 import { useLaunchContext } from '../common/base'
 import { MOCK_URL, sleep } from '../common/util'
-import { createLimitRule, fillTimeLimit, isLimitModalVisible, waitForLimitFrame } from "./common"
+import { createLimitRule, fillTimeLimit, isLimitModalVisible, queryLimitModalVisible, waitForLimitFrame, waitForLimitModal, waitForLimitModalHidden } from './common'
 
 describe('Daily limit', () => {
     const context = useLaunchContext()
@@ -84,7 +84,44 @@ describe('Daily limit', () => {
         expect(modalExist).toBeFalsy()
     }, 60000)
 
-    test("Daily visit limit", async () => {
+    test('blocks expired path after spa navigation', async () => {
+        const limitTime = 1
+        const blockedUrl = `${MOCK_URL}/home`
+        const limitPage = await context.openAppPage('/behavior/limit')
+        const demoRule: tt4b.limit.Rule = {
+            id: 1, name: 'TEST SPA DAILY LIMIT',
+            cond: [blockedUrl],
+            time: limitTime,
+            enabled: true, allowDelay: false, locked: false,
+        }
+
+        await createLimitRule(demoRule, limitPage)
+
+        // Exhaust limit via full navigation — background time tracking uses tab.url, not pushState
+        const blockedPage = await context.newPageAndWaitCsInjected(blockedUrl)
+        await blockedPage.bringToFront()
+        await waitForLimitModal(blockedPage)
+        await blockedPage.close()
+
+        const testPage = await context.newPageAndWaitCsInjected(MOCK_URL)
+        expect(await queryLimitModalVisible(testPage)).toBeFalsy()
+
+        await testPage.bringToFront()
+        await testPage.evaluate(url => history.pushState({}, '', url), blockedUrl)
+        await waitForLimitModal(testPage)
+        const limitFrame = await waitForLimitFrame(testPage)
+        await limitFrame.waitForFunction(() => {
+            const td = document.querySelector('#app .el-descriptions:not([style*="display: none"]) tr td:nth-child(2)')
+            return td?.textContent && td.textContent !== '-'
+        }, { timeout: 5000 })
+        expect(await queryLimitModalVisible(testPage)).toBeTruthy()
+
+        await testPage.evaluate(url => history.pushState({}, '', url), MOCK_URL)
+        await waitForLimitModalHidden(testPage)
+        expect(await queryLimitModalVisible(testPage)).toBeFalsy()
+    }, 60000)
+
+    test('Daily visit limit', async () => {
         const limitPage = await context.openAppPage('/behavior/limit')
         const demoRule: tt4b.limit.Rule = {
             id: 1, name: 'TEST DAILY VISIT LIMIT',

--- a/test/content-script/location-watcher.test.ts
+++ b/test/content-script/location-watcher.test.ts
@@ -1,0 +1,84 @@
+import LocationWatcher from '@cs/location-watcher'
+
+describe('LocationWatcher', () => {
+    beforeEach(() => {
+        history.replaceState({}, '', '/')
+    })
+
+    test('pushState triggers handler immediately', () => {
+        const initialUrl = window.location.href
+        const handler = rstest.fn()
+        const watcher = new LocationWatcher(initialUrl, handler)
+        watcher.init()
+
+        history.pushState({}, '', '/page-a')
+
+        expect(handler).toHaveBeenCalledTimes(1)
+        expect(handler).toHaveBeenCalledWith(`${window.location.origin}/page-a`, initialUrl)
+
+        watcher.dispose()
+    })
+
+    test('replaceState triggers handler immediately', () => {
+        const initialUrl = window.location.href
+        const handler = rstest.fn()
+        const watcher = new LocationWatcher(initialUrl, handler)
+        watcher.init()
+
+        history.replaceState({}, '', '/page-b')
+
+        expect(handler).toHaveBeenCalledTimes(1)
+        expect(handler).toHaveBeenCalledWith(`${window.location.origin}/page-b`, initialUrl)
+
+        watcher.dispose()
+    })
+
+    test('popstate still triggers handler', async () => {
+        history.replaceState({}, '', '/')
+        const rootUrl = window.location.href
+        history.pushState({}, '', '/page-a')
+        const pageAUrl = window.location.href
+        const handler = rstest.fn()
+        const watcher = new LocationWatcher(pageAUrl, handler)
+        watcher.init()
+
+        const popstate = new Promise<void>(resolve => {
+            window.addEventListener('popstate', () => resolve(), { once: true })
+        })
+        history.back()
+        await popstate
+
+        expect(handler).toHaveBeenCalledTimes(1)
+        expect(handler).toHaveBeenCalledWith(rootUrl, pageAUrl)
+
+        watcher.dispose()
+    })
+
+    test('dispose restores native history methods', () => {
+        const nativePushState = history.pushState
+        const nativeReplaceState = history.replaceState
+        const handler = rstest.fn()
+        const watcher = new LocationWatcher(window.location.href, handler)
+        watcher.init()
+
+        watcher.dispose()
+
+        expect(history.pushState).toBe(nativePushState)
+        expect(history.replaceState).toBe(nativeReplaceState)
+        history.pushState({}, '', '/page-after-dispose')
+        expect(handler).not.toHaveBeenCalled()
+    })
+
+    test('init is idempotent', () => {
+        const handler = rstest.fn()
+        const watcher = new LocationWatcher(window.location.href, handler)
+        watcher.init()
+        watcher.init()
+
+        history.pushState({}, '', '/page-a')
+
+        expect(handler).toHaveBeenCalledTimes(1)
+
+        watcher.dispose()
+    })
+})

--- a/test/util/limit.test.ts
+++ b/test/util/limit.test.ts
@@ -24,6 +24,17 @@ describe('util/limit', () => {
         expect(matches(cond, 'http://www.bilibili.com/cheese/list')).toBe(false)
         expect(matches(cond, 'http://t.bilibili.com/')).toBe(true)
         expect(matches(cond, 'https://www.bilibili.com/video/BV3527/')).toBe(true)
+
+        // Trailing slash checks
+        expect(matches(['example.com/'], 'https://example.com')).toBe(true)
+        expect(matches(['example.com'], 'https://example.com/')).toBe(true)
+        expect(matches(['example.com/path/'], 'https://example.com/path')).toBe(true)
+        expect(matches(['example.com/path'], 'https://example.com/path/')).toBe(true)
+        expect(matches(['example.com/path/'], 'https://example.com/path/?foo=bar')).toBe(true)
+        expect(matches(['example.com/path'], 'https://example.com/path?foo=bar')).toBe(true)
+
+        // Do not collapse a lone root slash into an empty pattern
+        expect(matches(['/'], 'https://example.com/')).toBe(false)
     })
 
     test('matchCond', () => {


### PR DESCRIPTION
## Summary

- Add `LocationWatcher` to detect SPA navigations via history API wrapping (`pushState`/`replaceState`), `popstate`, `hashchange`, and polling fallback
- Re-evaluate time and visit limits on route change, re-check whitelist per URL, and keep the limit modal synced to the current path
- Reset visit processor state on navigation; normalize trailing slashes in limit URL matching
- Add unit tests for `LocationWatcher` and an e2e test for SPA navigation blocking

Also manually tested both **time limits** and **visit limits** on dynamic (SPA) route changes.

## Test plan

- [x] `npm run build` passes
- [x] `npm run test` passes (81 tests)
- [x] `npx knip --treat-config-hints-as-errors` passes
- [x] Manual testing (Chromium): time limit blocks/unblocks on SPA route change 
- [x] Manual testing (Chromium): visit limit blocks/unblocks on SPA route change
- [x] CI unit tests
- [x] CI e2e tests