### PR TITLE
feat: add tooltips to site management tab

### DIFF
--- a/src/i18n/message/app/site-manage-resource.json
+++ b/src/i18n/message/app/site-manage-resource.json
@@ -111,9 +111,7 @@
             "icon": "Icon",
             "white": "Whitelist",
             "whiteInfo": "Whitelisted sites are not tracked or blocked.",
-            "runtime": "Run Time",
             "runtimeInfo": "Record the time a website is open. Does not require the website's tab to active, or the window to be focused.",
-            "mediaTime": "Media Time",
             "mediaTimeInfo": "Record the time a website is playing audio."
         },
         "typeInfo": {

--- a/src/i18n/message/app/site-manage-resource.json
+++ b/src/i18n/message/app/site-manage-resource.json
@@ -110,7 +110,11 @@
             "cate": "Site Category",
             "icon": "Icon",
             "white": "Whitelist",
-            "whiteInfo": "Whitelisted sites are not tracked or blocked."
+            "whiteInfo": "Whitelisted sites are not tracked or blocked.",
+            "runtime": "Run Time",
+            "runtimeInfo": "Record the time a website is open. Does not require the website's tab to active, or the window to be focused.",
+            "mediaTime": "Media Time",
+            "mediaTimeInfo": "Record the time a website is playing audio."
         },
         "typeInfo": {
             "normal": "statistics by domain name",

--- a/src/i18n/message/app/site-manage.ts
+++ b/src/i18n/message/app/site-manage.ts
@@ -16,6 +16,10 @@ export type SiteManageMessage = {
         icon: string
         white: string
         whiteInfo: string
+        runtime: string
+        runtimeInfo: string
+        mediaTime: string
+        mediaTimeInfo: string
     }
     typeInfo: Record<tt4b.site.Type, string>
     cate: {

--- a/src/i18n/message/app/site-manage.ts
+++ b/src/i18n/message/app/site-manage.ts
@@ -16,9 +16,7 @@ export type SiteManageMessage = {
         icon: string
         white: string
         whiteInfo: string
-        runtime: string
         runtimeInfo: string
-        mediaTime: string
         mediaTimeInfo: string
     }
     typeInfo: Record<tt4b.site.Type, string>

--- a/src/pages/app/components/SiteManage/Table/column/OptionsColumn.tsx
+++ b/src/pages/app/components/SiteManage/Table/column/OptionsColumn.tsx
@@ -34,28 +34,44 @@ const OptionsColumn = defineComponent<{ onChanged: NoArgCallback }>(props => {
                 }}
             />
             <ElTableColumn
-                label={t(msg => msg.item.run)}
+                label={t(msg => msg.siteManage.column.runtime)}
                 align='center'
-                v-slots={({ row }: RenderParam) => (
-                    <ElSwitch
-                        data-testid='run'
-                        size='small'
-                        modelValue={row.options?.run}
-                        onChange={val => changeOption(row, 'run', val)}
-                    />
-                )}
+                v-slots={{
+                    header: () => (
+                        <ColumnHeader
+                            label={t(msg => msg.siteManage.column.runtime)}
+                            tooltip={t(msg => msg.siteManage.column.runtimeInfo)}
+                        />
+                    ),
+                    default: ({ row }: RenderParam) => (
+                        <ElSwitch
+                            data-testid='run'
+                            size='small'
+                            modelValue={row.options?.run}
+                            onChange={val => changeOption(row, 'run', val)}
+                        />
+                    )
+                }}
             />
             <ElTableColumn
-                label={t(msg => msg.item.media)}
+                label={t(msg => msg.siteManage.column.mediaTime)}
                 align='center'
-                v-slots={({ row }: RenderParam) => (
-                    <ElSwitch
-                        data-testid='media'
-                        size='small'
-                        modelValue={row.options?.media}
-                        onChange={val => changeOption(row, 'media', val)}
-                    />
-                )}
+                v-slots={{
+                    header: () => (
+                        <ColumnHeader
+                            label={t(msg => msg.siteManage.column.mediaTime)}
+                            tooltip={t(msg => msg.siteManage.column.mediaTimeInfo)}
+                        />
+                    ),
+                    default: ({ row }: RenderParam) => (
+                        <ElSwitch
+                            data-testid='media'
+                            size='small'
+                            modelValue={row.options?.media}
+                            onChange={val => changeOption(row, 'media', val)}
+                        />
+                    )
+                }}
             />
         </ElTableColumn>
     )

--- a/src/pages/app/components/SiteManage/Table/column/OptionsColumn.tsx
+++ b/src/pages/app/components/SiteManage/Table/column/OptionsColumn.tsx
@@ -14,7 +14,6 @@ const OptionsColumn = defineComponent<{ onChanged: NoArgCallback }>(props => {
     return () => (
         <ElTableColumn align='center' label={t(msg => msg.button.configuration)}>
             <ElTableColumn
-                label={t(msg => msg.siteManage.column.white)}
                 align='center'
                 v-slots={{
                     header: () => (
@@ -34,12 +33,11 @@ const OptionsColumn = defineComponent<{ onChanged: NoArgCallback }>(props => {
                 }}
             />
             <ElTableColumn
-                label={t(msg => msg.siteManage.column.runtime)}
                 align='center'
                 v-slots={{
                     header: () => (
                         <ColumnHeader
-                            label={t(msg => msg.siteManage.column.runtime)}
+                            label={t(msg => msg.item.run)}
                             tooltip={t(msg => msg.siteManage.column.runtimeInfo)}
                         />
                     ),
@@ -54,12 +52,11 @@ const OptionsColumn = defineComponent<{ onChanged: NoArgCallback }>(props => {
                 }}
             />
             <ElTableColumn
-                label={t(msg => msg.siteManage.column.mediaTime)}
                 align='center'
                 v-slots={{
                     header: () => (
                         <ColumnHeader
-                            label={t(msg => msg.siteManage.column.mediaTime)}
+                            label={t(msg => msg.item.media)}
                             tooltip={t(msg => msg.siteManage.column.mediaTimeInfo)}
                         />
                     ),


### PR DESCRIPTION
This PR adds tooltips to the `Run Time` and `Media Time` columns in `Site Management`. Note that this PR adds an extra `i18n` key for "Run Time" and "Media Time".

## New
<img width="652" height="339" alt="Picture of Run Time tooltip" src="https://github.com/user-attachments/assets/63135e01-904c-4d47-8180-f052a90c082a" />

## Current
<img width="700" height="349" alt="image" src="https://github.com/user-attachments/assets/6df03f28-e994-4607-bfbe-c784219adec0" />
